### PR TITLE
SQL Style Guide を GitLab SQL Style Guide に変更

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,7 +1,7 @@
 # dbt Style Guide
 # https://github.com/dbt-labs/corp/blob/main/dbt_style_guide.md
 
-# SQL Style Guide
+# GitLab SQL Style Guide
 # https://about.gitlab.com/handbook/business-technology/data-team/platform/sql-style-guide/
 
 [sqlfluff]
@@ -26,7 +26,7 @@ comma_style = trailing
 indented_using_on = True
 
 [sqlfluff:rules:L010]
-# SQL Style Guide
+# GitLab SQL Style Guide
 group = core
 capitalisation_policy = upper
 
@@ -46,17 +46,17 @@ group = core
 comma_style = trailing
 
 [sqlfluff:rules:L030]
-# SQL Style Guide
+# GitLab SQL Style Guide
 group = core
 capitalisation_policy = upper
 
 [sqlfluff:rules:L036]
-# SQL Style Guide
+# GitLab SQL Style Guide
 group = core
 capitalisation_policy = upper
 
 [sqlfluff:rules:L040]
-# SQL Style Guide
+# GitLab SQL Style Guide
 group = core
 capitalisation_policy = upper
 
@@ -66,7 +66,7 @@ group = core
 group_by_and_order_by_style = implicit
 
 [sqlfluff:rules:L057]
-# SQL Style Guide
+# GitLab SQL Style Guide
 group = core
 allow_space_in_identifier = True
 additional_allowed_characters = ['.','(',')','-']


### PR DESCRIPTION
SQL Style Guide が GitLab のものであることを分かりやすくするため、リポジトリ内の SQL Style Guide という表記を GitLab SQL Style Guide に変更しています。